### PR TITLE
Hide video preview

### DIFF
--- a/toggle.js
+++ b/toggle.js
@@ -5,6 +5,9 @@ const youtubeCss = `
 .ytp-player-content, .ytp-ce-element {
   display: none !important;
 }
+.ytd-video-preview {
+  display: none !important;
+}
 .ytp-cued-thumbnail-overlay-image {
   z-index: 11;
 }


### PR DESCRIPTION
The video preview when you hover a video can spoil videos for you because it shows the length of the video briefly, so we disable it