### PR TITLE
Hide metatdata line in videos list

### DIFF
--- a/toggle.js
+++ b/toggle.js
@@ -7,6 +7,7 @@ const youtubeCss = `
 #description,
 #comments,
 #comment-teaser,
+.metadata-line,
 .ytp-progress-bar-container,
 .ytp-time-display,
 .ytThumbnailBottomOverlayViewModelHost,

--- a/toggle.js
+++ b/toggle.js
@@ -7,7 +7,7 @@ const youtubeCss = `
 #description,
 #comments,
 #comment-teaser,
-.metadata-line,
+#metadata-line,
 .ytp-progress-bar-container,
 .ytp-time-display,
 .ytThumbnailBottomOverlayViewModelHost,


### PR DESCRIPTION
When browsing videos, the metadata line (view count and upload date) may spoil results.

This is mostly an issue for live streams when you know the start time of the event, but the metadata when going to the "Live" tab of the channel shows "Streamed X hours ago", where "X" is the end of the live stream. 

For example, in case of a best of 3, if you see that the stream ended 3 hours ago and you know the series started 4 hours ago, and a game lasts 25 min on average with a small break between each game, it is easy to extrapolate that the winner of the first game wins the series, spoiling the second game result.